### PR TITLE
fix: comment out pnpm caching in frontend CI workflow

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'pnpm'
-          cache-dependency-path: './frontend/pnpm-lock.yaml'
+          #cache: 'pnpm'
+          #cache-dependency-path: './frontend/pnpm-lock.yaml'
       
       # Fix: Add pnpm store cache step
       - name: Get pnpm store directory


### PR DESCRIPTION
Breaking Changes : Commented out the pnpm cache dependency path because of the failing.