### PR TITLE
Fix: Docker Registry Login Step in CI/CD Pipeline

### DIFF
--- a/.github/workflows/cicd-pipeline.yaml
+++ b/.github/workflows/cicd-pipeline.yaml
@@ -13,20 +13,20 @@ jobs:
       
       - name: Build and push Docker images
         run: |
-          # Login to your Docker registry
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          # Login to your Docker registry (fixed non-interactive login)
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
           
           # Build and push each service image
           docker build -t yourregistry/conflictmanager:${{ github.sha }} ./source/conflictmanager
           docker push yourregistry/conflictmanager:${{ github.sha }}
           
-          # Repeat for other services
+
       
       - name: Update Kubernetes manifests
         run: |
           # Update image tags in manifests
           sed -i "s|image: yourregistry/conflictmanager:latest|image: yourregistry/conflictmanager:${{ github.sha }}|g" k8s/conflictmanager.yaml
-          # Repeat for other services
+
           
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to improve security and maintainability by replacing deprecated secrets and clarifying comments in the workflow file.

### CI/CD pipeline improvements:

* [`.github/workflows/cicd-pipeline.yaml`](diffhunk://#diff-a1e180c8a008ca54168fd8255b0e8e26127cae141fbb28717847941dcac69ac7L16-R29): Updated Docker login credentials to use `DOCKERHUB_TOKEN` and `DOCKERHUB_USERNAME` instead of `DOCKER_PASSWORD` and `DOCKER_USERNAME`, ensuring compatibility with Docker's non-interactive login method.