### PR TITLE
Fix : Reorganize CI/CD pipeline steps for clarity and improved Docker login process

### DIFF
--- a/.github/workflows/cicd-pipeline.yaml
+++ b/.github/workflows/cicd-pipeline.yaml
@@ -11,22 +11,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       
-      - name: Build and push Docker images
+      - name: Login to Docker Hub
         run: |
-          # Login to your Docker registry (fixed non-interactive login)
           echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
           
+      - name: Build and push Docker images
+        run: |
           # Build and push each service image
           docker build -t yourregistry/conflictmanager:${{ github.sha }} ./source/conflictmanager
           docker push yourregistry/conflictmanager:${{ github.sha }}
           
-
-      
       - name: Update Kubernetes manifests
         run: |
           # Update image tags in manifests
           sed -i "s|image: yourregistry/conflictmanager:latest|image: yourregistry/conflictmanager:${{ github.sha }}|g" k8s/conflictmanager.yaml
-
           
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'


### PR DESCRIPTION
This pull request makes a small but important improvement to the CI/CD pipeline by separating the Docker Hub login step from the Docker image build and push step in the `.github/workflows/cicd-pipeline.yaml` file.

### CI/CD Pipeline Updates:
* Split the "Build and push Docker images" step into two distinct steps: "Login to Docker Hub" and "Build and push Docker images." This change improves clarity and ensures that the Docker Hub login process is explicitly separated from the image build and push process. (`.github/workflows/cicd-pipeline.yaml`, [.github/workflows/cicd-pipeline.yamlL14-L30](diffhunk://#diff-a1e180c8a008ca54168fd8255b0e8e26127cae141fbb28717847941dcac69ac7L14-L30))