### PR TITLE
Fix : Enhance CI/CD pipeline: specify Dockerfile paths for service images

### DIFF
--- a/.github/workflows/cicd-pipeline.yaml
+++ b/.github/workflows/cicd-pipeline.yaml
@@ -26,21 +26,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      # Build and push all service images
+      # Build and push all service images with explicit Dockerfile paths
       - name: Build and push conflict manager image
         uses: docker/build-push-action@v4
         with:
           context: ./source/conflictmanager
+          file: ./source/conflictmanager/Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/conflictmanager:${{ github.sha }},${{ secrets.DOCKERHUB_USERNAME }}/conflictmanager:latest
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/conflictmanager:latest
           cache-to: type=inline
       
-      # Add similar blocks for other services
       - name: Build and push user manager image
         uses: docker/build-push-action@v4
         with:
           context: ./source/usermanager
+          file: ./source/usermanager/Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/usermanager:${{ github.sha }},${{ secrets.DOCKERHUB_USERNAME }}/usermanager:latest
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/usermanager:latest
@@ -50,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./source/frontend
+          file: ./source/frontend/Dockerfile
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/frontend:${{ github.sha }},${{ secrets.DOCKERHUB_USERNAME }}/frontend:latest
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/frontend:latest


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configuration to include explicit Dockerfile paths for building and pushing service images. This change ensures that the correct Dockerfiles are used for each service, improving clarity and reducing potential errors.

### CI/CD Pipeline Enhancements:

* [`.github/workflows/cicd-pipeline.yaml`](diffhunk://#diff-a1e180c8a008ca54168fd8255b0e8e26127cae141fbb28717847941dcac69ac7L29-R44): Added explicit `file` parameters to specify Dockerfile paths for the `conflictmanager`, `usermanager`, and `frontend` services in the `docker/build-push-action` steps. This ensures the correct Dockerfiles are used during image builds. [[1]](diffhunk://#diff-a1e180c8a008ca54168fd8255b0e8e26127cae141fbb28717847941dcac69ac7L29-R44) [[2]](diffhunk://#diff-a1e180c8a008ca54168fd8255b0e8e26127cae141fbb28717847941dcac69ac7R54)