### PR TITLE
Fix : Add Dockerfile for user manager service to fix the CI/CD pipeline failing

### DIFF
--- a/source/usermanager/Dockerfile
+++ b/source/usermanager/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3-openjdk-17-slim AS build
+ENV TZ="Asia/Kolkata"
+WORKDIR /usr/src/app
+COPY pom.xml ./
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /usr/src/app/target/usermanager-*.jar usermanager.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "usermanager.jar"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` for the `usermanager` service to enable containerization. The file includes a multi-stage build process to optimize the final image size and runtime environment.

Containerization setup:

* [`source/usermanager/Dockerfile`](diffhunk://#diff-f387541ab6ad3939340f24fe1db788b4e75bc191d9e3ec8647fc68ea2b9921a4R1-R12): Added a multi-stage build process using a Maven-based build stage (`maven:3-openjdk-17-slim`) to compile the application and an optimized runtime stage (`eclipse-temurin:17-jre-alpine`) to run the application. The Dockerfile sets the timezone, exposes port 8080, and defines the entry point for the application.