### PR TITLE
Fix: Update Kubernetes manifest to resolve CI/CD pipeline failure

### DIFF
--- a/.github/workflows/cicd-pipeline.yaml
+++ b/.github/workflows/cicd-pipeline.yaml
@@ -57,25 +57,31 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/frontend:latest
           cache-to: type=inline
       
-      # Update Kubernetes manifests with new image tags
+      # Update Kubernetes manifests with new image tags (only if directory exists)
       - name: Update Kubernetes manifests
         run: |
-          # Update image tags in manifests
-          find ./k8s -type f -name "*.yaml" -exec sed -i "s|image: yourregistry/|image: ${{ secrets.DOCKERHUB_USERNAME }}/|g" {} \;
-          find ./k8s -type f -name "*.yaml" -exec sed -i "s|:latest|:${{ github.sha }}|g" {} \;
+          if [ -d "./k8s" ]; then
+            # Update image tags in manifests
+            find ./k8s -type f -name "*.yaml" -exec sed -i "s|image: yourregistry/|image: ${{ secrets.DOCKERHUB_USERNAME }}/|g" {} \;
+            find ./k8s -type f -name "*.yaml" -exec sed -i "s|:latest|:${{ github.sha }}|g" {} \;
+            echo "Kubernetes manifests updated successfully"
+          else
+            echo "The k8s directory does not exist. Skipping manifest updates."
+          fi
       
-      # Configure Git for committing changes
-      - name: Configure Git
+      # Configure Git for committing changes (only if k8s directory exists)
+      - name: Configure Git and Commit Changes
         run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-      
-      # Commit and push updated manifests
-      - name: Commit updated manifests
-        run: |
-          git add ./k8s/
-          git commit -m "Update image tags to ${{ github.sha }} [skip ci]" || echo "No changes to commit"
-          git push
+          if [ -d "./k8s" ] && [ -n "$(git status --porcelain ./k8s)" ]; then
+            git config --global user.name 'GitHub Actions'
+            git config --global user.email 'actions@github.com'
+            git add ./k8s/
+            git commit -m "Update image tags to ${{ github.sha }} [skip ci]"
+            git push
+            echo "Changes committed and pushed"
+          else
+            echo "No k8s directory or no changes to commit"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/deployments/k8s/userManagement/usermanager-deployment.yaml
+++ b/deployments/k8s/userManagement/usermanager-deployment.yaml
@@ -1,0 +1,39 @@
+# Example k8s/usermanager-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: usermanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: usermanager
+  template:
+    metadata:
+      labels:
+        app: usermanager
+    spec:
+      containers:
+      - name: usermanager
+        image: ravinbanda/usermanager:latest
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: usermanager
+spec:
+  selector:
+    app: usermanager
+  ports:
+  - port: 8080
+    targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
This pull request introduces conditional logic to the CI/CD pipeline for handling Kubernetes manifests and adds a new Kubernetes deployment and service configuration for the `usermanager` application. These changes aim to enhance the pipeline's flexibility and expand deployment capabilities.

### CI/CD Pipeline Enhancements:
* Updated the `Update Kubernetes manifests` step in `.github/workflows/cicd-pipeline.yaml` to check if the `k8s` directory exists before attempting to update image tags. This ensures the pipeline gracefully skips manifest updates if the directory is missing.
* Modified the `Configure Git and Commit Changes` step to conditionally configure Git and commit changes only if the `k8s` directory exists and contains modifications. This prevents unnecessary Git operations.

### Kubernetes Deployment Addition:
* Added a new Kubernetes deployment and service configuration in `deployments/k8s/userManagement/usermanager-deployment.yaml` for the `usermanager` application. This includes resource limits, a single replica, and a `ClusterIP` service exposing port 8080.